### PR TITLE
Fix funResultTy so @funResultTy ANY _ = ANY@.

### DIFF
--- a/src/Data/Rank1Typeable.hs
+++ b/src/Data/Rank1Typeable.hs
@@ -234,6 +234,7 @@ funResultTy :: TypeRep -> TypeRep -> Either TypeError TypeRep
 funResultTy (splitTyConApp -> (fc, [farg, fres])) x | fc == funTc = do
   s <- unify (alphaRename "f" farg) (alphaRename "x" x)
   return (normalize (subst s (alphaRename "f" fres)))
+funResultTy f@(isTypVar -> Just _) _ = return f
 funResultTy f _ =
   Left $ show f ++ " is not a function"
 


### PR DESCRIPTION
Without this patch `funResTy` would refuse to return a useful type when given

```
Prelude Data.Rank1Typeable> funResultTy (typeOf (undefined :: ANY)) (typeOf (id :: ANY -> ANY))
Left "ANY is not a function"
```

After the patch

```
Prelude Data.Rank1Typeable> funResultTy (typeOf (undefined :: ANY)) (typeOf (id :: ANY -> ANY))
Right ANY
```

which corresponds to what is obtained when inferring types for `undefined id`

```
Prelude> :t undefined id
undefined id :: t
```
