### PR TITLE
Change TypVar from an empty datatype to a newtype-wrapped Any.

### DIFF
--- a/src/Data/Rank1Typeable.hs
+++ b/src/Data/Rank1Typeable.hs
@@ -105,6 +105,7 @@ import Data.Typeable (Typeable, mkTyCon3)
 import Data.Typeable.Internal (listTc, funTc, TyCon(TyCon), tyConName)
 import Data.Binary (Binary(get, put))
 import GHC.Fingerprint.Type (Fingerprint(..))
+import GHC.Exts(Any)
 import qualified Data.Typeable as Typeable
   ( TypeRep
   , typeOf
@@ -190,10 +191,10 @@ skolem = let (c, _) = splitTyConApp (typeOf (undefined :: Skolem V0)) in c
 -- Type variables                                                             --
 --------------------------------------------------------------------------------
 
-data TypVar a deriving Typeable
-data Skolem a deriving Typeable
-data Zero     deriving Typeable
-data Succ a   deriving Typeable
+newtype TypVar a = TypVar Any deriving Typeable
+data Skolem a                 deriving Typeable
+data Zero                     deriving Typeable
+data Succ a                   deriving Typeable
 
 type V0 = Zero
 type V1 = Succ V0


### PR DESCRIPTION
The following module defines a function `test` of type `a -> b` which evaluates its argument and then crashes with `undefined`:

``` haskell
import Data.Rank1Typeable
import Data.Rank1Dynamic

test :: ANY -> ANY1
test x = x `seq` undefined

oops :: (Typeable a, Typeable b) => a -> b
oops x = fromRight (toDynamic test `dynApply` toDynamic x >>= fromDynamic)
  where
    fromRight (Right x) = x
```

`oops x` is simply doing `test x` but with everything wrapped in `Dynamic`. Evaluating, say, `oops False :: Int` should clearly crash, because `test False = undefined`, but instead we get:

```
*Main> oops False :: Int
140055520632632
```

What is happening here? Looking at the generated core shows what's going on:

```
Test.test :: Data.Rank1Typeable.ANY -> Data.Rank1Typeable.ANY1
[GblId, Arity=1, Caf=NoCafRefs, Str=DmdType <L,U>b]
Test.test =
  \ (x_aHK :: Data.Rank1Typeable.ANY) ->
    case x_aHK of _ [Occ=Dead] { }
```

GHC has compiled the `seq` into a case analysis on `x`, which is of type `ANY`, a synonym for `TypVar V0`. However, `TypVar` is defined as a datatype with no constructors, so the generated case-expression has no cases! This is perfectly valid code given that `test :: ANY -> ANY1`, but then `Data.Rank1Dynamic` comes along and casts `test` to `Bool -> Int`, and the core above obviously cannot work.

The solution is not to define `TypVar` as an empty datatype, but instead to define it as a newtype wrapper for `GHC.Exts.Any`, which gives us permission to instantiate `TypVar`s with whatever we like. The attached patch does this, and now `test` behaves as it should:

```
*Test> oops False :: Int
*** Exception: Prelude.undefined
```
