### PR TITLE
Ghc 7.10

### DIFF
--- a/rank1dynamic.cabal
+++ b/rank1dynamic.cabal
@@ -32,7 +32,6 @@ Library
                        EmptyDataDecls,
                        ExistentialQuantification,
                        DeriveDataTypeable,
-                       KindSignatures,
                        PolyKinds,
                        RankNTypes,
                        StandaloneDeriving,
@@ -43,12 +42,10 @@ Test-Suite TestRank1Dynamic
   Type:              exitcode-stdio-1.0
   Main-Is:           test.hs
   Build-Depends:     base >= 4.4 && < 5,
+                     constraints >= 0.4 && < 0.5,
                      HUnit >= 1.2 && < 1.3,
                      rank1dynamic,
                      test-framework >= 0.6 && < 0.9,
                      test-framework-hunit >= 0.2.0 && < 0.4
-  if impl(ghc >= 7.8)
-    Build-Depends:   constraints >= 0.4 && < 0.5
   ghc-options:       -Wall -Werror
-  Extensions:        CPP
   HS-Source-Dirs:    tests

--- a/src/Data/Rank1Dynamic.hs
+++ b/src/Data/Rank1Dynamic.hs
@@ -27,9 +27,6 @@
 -- >      return $ (abstractConstraints (f :: Dict (Monad Maybe) -> Int -> Maybe Int)) 0
 -- > Right (Just 0)
 --
--- Please, see @tests/test.hs@ for examples of how to write the higher-kinded
--- case in ghc versions earlier than 7.6.3.
---
 -- [Examples of dynApply]
 --
 -- These examples correspond to the 'Data.Rank1Typeable.funResultTy' examples

--- a/src/Data/Rank1Typeable.hs
+++ b/src/Data/Rank1Typeable.hs
@@ -56,7 +56,7 @@
 -- > (\Dict -> return) :: Dict (Monad ANY) -> ANY1 -> ANY (ANY1 :: *)
 --
 -- Please, see @tests/test.hs@ for examples of how to write the higher-kinded
--- cases in ghc versions earlier than 7.8.3.
+-- cases in ghc versions earlier than 7.6.3.
 --
 -- [Examples of funResultTy]
 --
@@ -126,17 +126,6 @@ import Control.Applicative ((<$>))
 import Data.List (intersperse, isPrefixOf)
 import Data.Maybe (fromMaybe)
 import Data.Typeable (Typeable, mkTyCon3)
-#if !MIN_VERSION_base(4,7,0)
-import Data.Typeable
-  ( Typeable1(..)
-  , Typeable2(..)
-  , Typeable3(..)
-  , Typeable4(..)
-  , Typeable5(..)
-  , Typeable6(..)
-  , Typeable7(..)
-  )
-#endif
 import Data.Typeable.Internal (listTc, funTc, TyCon(TyCon), tyConName)
 import Data.Binary (Binary(get, put))
 import GHC.Fingerprint.Type (Fingerprint(..))
@@ -234,40 +223,14 @@ skolem = let (c, _) = splitTyConApp (typeOf (undefined :: Skolem V0)) in c
 --------------------------------------------------------------------------------
 
 -- | Internal tag to distinguish our uses of Any from user's.
-data T               deriving Typeable
+data T        deriving Typeable
 
 type TypVar = Any T
-data Skolem (a :: *) deriving Typeable
-data Zero            deriving Typeable
-data Succ   (a :: *) deriving Typeable
+data Skolem a deriving Typeable
+data Zero     deriving Typeable
+data Succ a   deriving Typeable
 
-#if MIN_VERSION_base(4,7,0)
 deriving instance Typeable Any
-#else
-instance Typeable Any where
-  typeOf _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable1 Any where
-  typeOf1 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable2 Any where
-  typeOf2 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable3 Any where
-  typeOf3 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable4 Any where
-  typeOf4 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable5 Any where
-  typeOf5 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable6 Any where
-  typeOf6 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-
-instance Typeable7 Any where
-  typeOf7 _ = Typeable.mkTyConApp (mkTyCon3 "ghc-prim" "GHC.Prim" "Any") []
-#endif
 
 type V0 = Zero
 type V1 = Succ V0

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,10 +1,3 @@
-#if !MIN_VERSION_base(4,7,0)
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ExistentialQuantification #-}
-#if !MIN_VERSION_base(4,6,0)
-{-# LANGUAGE KindSignatures #-}
-#endif
-#endif
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -12,11 +5,7 @@
 import Data.Rank1Typeable
 import Data.Rank1Dynamic
 
-#if MIN_VERSION_base(4,7,0)
 import Data.Constraint (Dict(..))
-#else
-import qualified Data.Typeable as Typeable (Typeable(..),Typeable1(..), mkTyCon3, mkTyConApp)
-#endif
 import Test.HUnit hiding (Test)
 import Test.Framework
 import Test.Framework.Providers.HUnit
@@ -26,18 +15,7 @@ import Unsafe.Coerce
 main :: IO ()
 main = defaultMain tests
 
-#if MIN_VERSION_base(4,7,0)
 deriving instance Typeable Monad
-#else
-data MonadDict m = Monad m => MonadDict
-
-instance Typeable.Typeable1 m => Typeable (MonadDict m) where
-  typeOf _ = Typeable.mkTyConApp (Typeable.mkTyCon3 "main" "Main" "MonadDict")
-               [ Typeable.typeOf1 (undefined :: m a) ]
-
-returnD :: MonadDict m -> a -> m a
-returnD MonadDict = return
-#endif
 
 tests :: [Test]
 tests =
@@ -64,36 +42,18 @@ tests =
 
       , testCase "CANNOT use a term of type 'forall a. a -> a' as 'forall a. a'" $
           typeOf (undefined :: ANY) `isInstanceOf` typeOf (undefined :: ANY -> ANY)
-#if MIN_VERSION_base(4,7,0)
           @?= Left "Cannot unify Skolem and (->)"
-#else
-          @?= Left "Cannot unify Skolem and ->"
-#endif
 
       , testCase "CAN use a term of type 'forall a. a -> m a' as 'Int -> Maybe Int'" $
           typeOf (undefined :: Int -> Maybe Int)
             `isInstanceOf`
-#if MIN_VERSION_base(4,6,0)
                typeOf (undefined :: ANY1 -> ANY ANY1)
-#else
-               typeOf (undefined :: ANY1 -> ANY (ANY1 :: *))
-#endif
           @?= Right ()
 
       , testCase "CAN use a term of type 'forall a. Monad a => a -> m a' as 'Int -> Maybe Int'" $
-#if MIN_VERSION_base(4,7,0)
           typeOf ((\Dict -> return) :: Dict (Monad Maybe) -> Int -> Maybe Int)
             `isInstanceOf`
                typeOf ((\Dict -> return) :: Dict (Monad ANY) -> ANY1 -> ANY ANY1)
-#else
-          typeOf (returnD :: MonadDict Maybe -> Int -> Maybe Int)
-            `isInstanceOf`
-#if MIN_VERSION_base(4,6,0)
-               typeOf (returnD :: MonadDict ANY -> ANY1 -> ANY ANY1)
-#else
-               typeOf (returnD :: MonadDict ANY -> ANY1 -> ANY (ANY1 :: *))
-#endif
-#endif
           @?= Right ()
       ]
 
@@ -149,20 +109,11 @@ tests =
 
       , testCase "CANNOT use a term of type 'forall a. a -> a' as 'forall a. a'" $
           do f <- fromDynamic (toDynamic (id :: ANY -> ANY)) ; return $ (f :: Int)
-#if MIN_VERSION_base(4,7,0)
           @?= Left "Cannot unify Int and (->)"
-#else
-          @?= Left "Cannot unify Int and ->"
-#endif
 
       , testCase "CAN use a term of type 'forall a. Monad a => a -> m a' as 'Int -> Maybe Int'" $
-#if MIN_VERSION_base(4,7,0)
           do f <- fromDynamic (toDynamic ((\Dict -> return) :: Dict (Monad Maybe) -> Int -> Maybe Int))
              return $ (f :: Dict (Monad Maybe) -> Int -> Maybe Int) Dict 0
-#else
-          do f <- fromDynamic (toDynamic (returnD :: MonadDict Maybe -> Int -> Maybe Int))
-             return $ ((f :: MonadDict Maybe -> Int -> Maybe Int) MonadDict) 0
-#endif
           @?= Right (Just 0)
       ]
 


### PR DESCRIPTION
Polykinds feature became incompatible with ghc-7.10. And there is not much users for this feature.
As a result a simple solution to make cloud-haskell work on 7.10 is to disable this feature until better solution will be found.  