### PR TITLE
update min GHC version

### DIFF
--- a/rank1dynamic.cabal
+++ b/rank1dynamic.cabal
@@ -23,7 +23,7 @@ Source-Repository head
 Library
   Exposed-Modules:     Data.Rank1Dynamic,
                        Data.Rank1Typeable
-  Build-Depends:       base >= 4.6 && < 5,
+  Build-Depends:       base >= 4.8 && < 5,
                        binary >= 0.5 && < 0.9
   HS-Source-Dirs:      src
   GHC-Options:         -Wall


### PR DESCRIPTION
rank1dynamic can't be built on GHC =< 7.8. This patch reflects that in dependency files.